### PR TITLE
Prevent issuing unsupported queries

### DIFF
--- a/pgcli/pgexecute.py
+++ b/pgcli/pgexecute.py
@@ -588,8 +588,8 @@ class PGExecute(object):
     def foreignkeys(self):
         """Yields ForeignKey named tuples"""
 
-        if self.conn.server_version < 90000:
-            return
+        # Materialize doesn't support several aspects of the following query.
+        return
 
         with self.conn.cursor() as cur:
             query = """
@@ -627,6 +627,10 @@ class PGExecute(object):
 
     def functions(self):
         """Yields FunctionMetadata named tuples"""
+
+        # Materialize doesn't support the Postgres constructs used in any of
+        # the below queries.
+        return
 
         if self.conn.server_version >= 110000:
             query = """


### PR DESCRIPTION
MaterializeInc/materialize#711 made it so that we report
Postgres 12.0 as our server version, which triggers 
various unsupported introspective queries. This change
disables those queries.

Fixes #3