### PR TITLE
Default to connecting as user materialize

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -112,6 +112,7 @@ Contributors:
     * Anthony DeBarros (anthonydb)
     * Seungyong Kwak (GUIEEN)
     * Tom Caruso (tomplex)
+    * Chris Golden (cirego)
 
 Creator:
 --------

--- a/changelog.rst
+++ b/changelog.rst
@@ -19,6 +19,14 @@ Bug fixes:
 * Move from `humanize` to `pendulum` for displaying query durations (#1015)
 * More explicit error message when connecting using DSN alias and it is not found.
 
+3.0.1
+=====
+
+Bug fixes:
+----------
+
+* Default to using "materialize" as the username -- see MaterializeInc/materialize#5555.
+
 3.0.0
 =====
 
@@ -1060,3 +1068,4 @@ Improvements:
 .. _`thegeorgeous`: https://github.com/thegeorgeous
 .. _`laixintao`: https://github.com/laixintao
 .. _`anthonydb`: https://github.com/anthonydb
+.. _`Chris Golden`: https://github.com/cirego

--- a/mzcli/main.py
+++ b/mzcli/main.py
@@ -506,7 +506,7 @@ class PGCli(object):
         # Connect to the database.
 
         if not user:
-            user = getuser()
+            user = "materialize"
 
         if not database:
             # every materialize instance comes with a "materialize" db

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -27,28 +27,28 @@ from collections import namedtuple
 def test_obfuscate_process_password():
     original_title = setproctitle.getproctitle()
 
-    setproctitle.setproctitle("mzcli user=root password=secret host=localhost")
+    setproctitle.setproctitle("mzcli user=materialize password=secret host=localhost")
     obfuscate_process_password()
     title = setproctitle.getproctitle()
-    expected = "mzcli user=root password=xxxx host=localhost"
+    expected = "mzcli user=materialize password=xxxx host=localhost"
     assert title == expected
 
-    setproctitle.setproctitle("mzcli user=root password=top secret host=localhost")
+    setproctitle.setproctitle("mzcli user=materialize password=top secret host=localhost")
     obfuscate_process_password()
     title = setproctitle.getproctitle()
-    expected = "mzcli user=root password=xxxx host=localhost"
+    expected = "mzcli user=materialize password=xxxx host=localhost"
     assert title == expected
 
-    setproctitle.setproctitle("mzcli user=root password=top secret")
+    setproctitle.setproctitle("mzcli user=materialize password=top secret")
     obfuscate_process_password()
     title = setproctitle.getproctitle()
-    expected = "mzcli user=root password=xxxx"
+    expected = "mzcli user=materialize password=xxxx"
     assert title == expected
 
-    setproctitle.setproctitle("mzcli postgres://root:secret@localhost/db")
+    setproctitle.setproctitle("mzcli postgres://materialize:secret@localhost/db")
     obfuscate_process_password()
     title = setproctitle.getproctitle()
-    expected = "mzcli postgres://root:xxxx@localhost/db"
+    expected = "mzcli postgres://materialize:xxxx@localhost/db"
     assert title == expected
 
     setproctitle.setproctitle(original_title)


### PR DESCRIPTION
As of MaterializeInc/materialize#5555, we require a valid user. Default
to using the "materialize" user (defaulting to get_user() causes us to
try and connect as "root" under Docker).

## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.rst`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
<!-- We would appreciate if you comply with our code style guidelines. -->
- [x] I installed pre-commit hooks (`pip install pre-commit && pre-commit install`), and ran `black` on my code.
- [x] Please squash merge this pull request (uncheck if you'd like us to merge as multiple commits)
